### PR TITLE
Fix IterableWeakMap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ class IterableWeakMap {
     this.#weakMap.set(key, { value, ref });
     this.#refMap.set(ref, value);
     this.#finalizationGroup.register(key, {
-      map: this.#weakMap,
+      map: this.#refMap,
       ref
     }, ref);
   }


### PR DESCRIPTION
The `FinalizationGroup` holding value should contain the `#refMap` to later delete the `ref` entry, not the `#weakMap` which contains target as keys and are gone by that point.